### PR TITLE
Add required args example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,3 +3,4 @@
 * print - Take a string and print it to stdout
 * commands - Basic example of using commands
 * commands-advanced - Advanced usage of commands with sub-commands and argument scoping
+* required-args - Basic example of required vs optional string arguments

--- a/examples/required-args/README.md
+++ b/examples/required-args/README.md
@@ -1,0 +1,50 @@
+# Required vs Optional Arguments
+
+The purpose of this example is to demonstrate the difference between required
+and optional arguments using string arguments.
+
+## Setup
+
+The first step for any project is to build a new parser:
+
+```go
+parser := argparse.NewParser("Required-args", "Example of required vs optional arguments")
+```
+
+For this demonstration, two shorthand arguments are used:
+
+```go
+// Required shorthand argument
+foo := parser.String("f", "foo", &argparse.Options{Required: true, Help: "foo is a required string option"})
+
+// Optional shorthand argument
+bar := parser.String("b", "bar", &argparse.Options{Required:false, Help: "bar is not a required option"})
+```
+
+`foo` is a required string argument, and `bar` is an optional string argument.
+
+Using `required-arguments.go` without foo demonstrates this:
+
+```bash
+$ go run required-args.go
+[-f|--foo] is required
+usage: Required-args [-h|--help] -f|--foo "<value>" [-b|--bar "<value>"]
+
+                     Example of required vs optional arguments
+
+Arguments:
+
+   -h   --help    Print help information
+   -f   --foo     foo is a required string option
+   -b   --bar     bar is not a required option
+
+
+```
+
+Output when foo is provided:
+
+```bash
+$ go run required-args.go --foo foo
+Provided arguments:
+foo (required): foo
+```

--- a/examples/required-args/required-args.go
+++ b/examples/required-args/required-args.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"github.com/akamensky/argparse"
+	"os"
+)
+
+func main() {
+	parser := argparse.NewParser("Required-args", "Example of required vs optional arguments")
+
+	// Required shorthand argument
+	foo := parser.String("f", "foo", &argparse.Options{Required: true, Help: "foo is a required string option"})
+
+	// Optional shorthand argument
+	bar := parser.String("b", "bar", &argparse.Options{Required: false, Help: "bar is not a required option"})
+
+	// Parse args
+	err := parser.Parse(os.Args)
+	if err != nil {
+		fmt.Print(parser.Usage(err))
+	} else {
+		fmt.Println("Provided arguments:")
+		fmt.Printf("foo (required): %s\n", *foo)
+
+		// As an optional string argument, bar will be empty if unused
+		if *bar != "" {
+			fmt.Printf("bar (optional): %s\n", *bar)
+		}
+	}
+}


### PR DESCRIPTION
A simple example I made using string arguments to demonstrate required args while getting started with this project.

I also included some documentation to go along with it (similar to the Python explanation of the `argparse` module) in case updating large examples becomes cumbersome in the future when changes to the code base occur, or you decided to move to something like [Read the Docs](https://readthedocs.org/). 