### PR TITLE
refine Usage to print last command help

### DIFF
--- a/argparse.go
+++ b/argparse.go
@@ -19,6 +19,7 @@ type Command struct {
 	args        []*arg
 	commands    []*Command
 	parsed      bool
+	happened    bool
 	parent      *Command
 }
 
@@ -255,7 +256,7 @@ func (o *Command) Selector(short string, long string, options []string, opts *Op
 // Happened shows whether Command was specified on CLI arguments or not. If Command did not "happen", then
 // all its descendant commands and arguments are not parsed. Returns a boolean value.
 func (o *Command) Happened() bool {
-	return o.parsed
+	return o.happened
 }
 
 // Usage returns a multiline string that is the same as a help message for this Parser or Command.
@@ -266,6 +267,11 @@ func (o *Command) Happened() bool {
 // Accepts an interface that can be error, string or fmt.Stringer that will be prepended to a message.
 // All other interface types will be ignored
 func (o *Command) Usage(msg interface{}) string {
+	for _, cmd := range o.commands {
+		if cmd.Happened() {
+			return cmd.Usage(msg)
+		}
+	}
 	var result string
 	// Stay classy
 	maxWidth := 80

--- a/command.go
+++ b/command.go
@@ -63,6 +63,9 @@ func (o *Command) parse(args *[]string) error {
 		}
 	}
 
+	// Set happened status to true when command happend
+	o.happened = true
+
 	// Reduce arguments by removing Command name
 	*args = (*args)[1:]
 


### PR DESCRIPTION
when sub command args parse failed, it is useful to check which sub command happened and print it's usage message, but not always print top level command usage.