### PR TITLE
Customizable Help Functions

### DIFF
--- a/argparse.go
+++ b/argparse.go
@@ -22,7 +22,7 @@ type Command struct {
 	parsed      bool
 	happened    bool
 	parent      *Command
-	HelpFunc    func(c Command, msg interface{}) string
+	HelpFunc    func(c *Command, msg interface{}) string
 }
 
 // GetName exposes Command's name field
@@ -55,13 +55,13 @@ func (o Command) GetParent() *Command {
 
 // Help calls the overriddable Command.HelpFunc on itself,
 // called when the help argument strings are passed via CLI
-func (o Command) Help(msg interface{}) string {
+func (o *Command) Help(msg interface{}) string {
 	tempC := o
 	for tempC.HelpFunc == nil {
 		if tempC.parent == nil {
 			return ""
 		}
-		tempC = *tempC.parent
+		tempC = tempC.parent
 	}
 	return tempC.HelpFunc(o, msg)
 }
@@ -110,7 +110,7 @@ func NewParser(name string, description string) *Parser {
 	p.commands = make([]*Command, 0)
 
 	p.help()
-	p.HelpFunc = Command.Usage
+	p.HelpFunc = (*Command).Usage
 
 	return p
 }
@@ -310,7 +310,7 @@ func (o *Command) Happened() bool {
 //
 // Accepts an interface that can be error, string or fmt.Stringer that will be prepended to a message.
 // All other interface types will be ignored
-func (o Command) Usage(msg interface{}) string {
+func (o *Command) Usage(msg interface{}) string {
 	for _, cmd := range o.commands {
 		if cmd.Happened() {
 			return cmd.Usage(msg)
@@ -323,7 +323,7 @@ func (o Command) Usage(msg interface{}) string {
 	arguments := make([]*arg, 0)
 	// First get line of commands until root
 	var chain []string
-	current := &o
+	current := o
 	if msg != nil {
 		switch msg.(type) {
 		case subCommandError:

--- a/argparse.go
+++ b/argparse.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 )
 
+// DisableDescription can be assigned as a command or arguments description to hide it from the Usage output
 const DisableDescription = "DISABLEDDESCRIPTIONWILLNOTSHOWUP"
 
 // Command is a basic type for this package. It represents top level Parser as well as any commands and sub-commands
@@ -21,6 +22,48 @@ type Command struct {
 	parsed      bool
 	happened    bool
 	parent      *Command
+	HelpFunc    func(c Command, msg interface{}) string
+}
+
+// GetName exposes Command's name field
+func (o Command) GetName() string {
+	return o.name
+}
+
+// GetDescription exposes Command's description field
+func (o Command) GetDescription() string {
+	return o.description
+}
+
+// GetArgs exposes Command's args field
+func (o Command) GetArgs() (args []Arg) {
+	for _, arg := range o.args {
+		args = append(args, arg)
+	}
+	return
+}
+
+// GetCommands exposes Command's commands field
+func (o Command) GetCommands() []*Command {
+	return o.commands
+}
+
+// GetParent exposes Command's parent field
+func (o Command) GetParent() *Command {
+	return o.parent
+}
+
+// Help calls the overriddable Command.HelpFunc on itself,
+// called when the help argument strings are passed via CLI
+func (o Command) Help(msg interface{}) string {
+	tempC := o
+	for tempC.HelpFunc == nil {
+		if tempC.parent == nil {
+			return ""
+		}
+		tempC = *tempC.parent
+	}
+	return tempC.HelpFunc(o, msg)
 }
 
 // Parser is a top level object of argparse. It MUST NOT ever be created manually. Instead one should use
@@ -67,6 +110,7 @@ func NewParser(name string, description string) *Parser {
 	p.commands = make([]*Command, 0)
 
 	p.help()
+	p.HelpFunc = Command.Usage
 
 	return p
 }
@@ -266,7 +310,7 @@ func (o *Command) Happened() bool {
 //
 // Accepts an interface that can be error, string or fmt.Stringer that will be prepended to a message.
 // All other interface types will be ignored
-func (o *Command) Usage(msg interface{}) string {
+func (o Command) Usage(msg interface{}) string {
 	for _, cmd := range o.commands {
 		if cmd.Happened() {
 			return cmd.Usage(msg)
@@ -279,7 +323,7 @@ func (o *Command) Usage(msg interface{}) string {
 	arguments := make([]*arg, 0)
 	// First get line of commands until root
 	var chain []string
-	current := o
+	current := &o
 	if msg != nil {
 		switch msg.(type) {
 		case subCommandError:

--- a/argparse_examples_test.go
+++ b/argparse_examples_test.go
@@ -1,0 +1,74 @@
+package argparse
+
+import "fmt"
+
+func ExampleCommand_Help() {
+	parser := NewParser("parser", "")
+	parser.HelpFunc = func(c *Command, msg interface{}) string {
+		return fmt.Sprintf("Name: %s\n", c.GetName())
+	}
+	fmt.Println(parser.Help(nil))
+
+	// Output:
+	// Name: parser
+}
+
+func ExampleCommand_Help_subcommandDefaulting() {
+	parser := NewParser("parser", "")
+	parser.HelpFunc = func(c *Command, msg interface{}) string {
+		helpString := fmt.Sprintf("Name: %s\n", c.GetName())
+		for _, com := range c.GetCommands() {
+			// Calls parser.HelpFunc, because command.HelpFuncs are nil
+			helpString += com.Help(nil)
+		}
+		return helpString
+	}
+	parser.NewCommand("subcommand1", "")
+	parser.NewCommand("subcommand2", "")
+	fmt.Println(parser.Help(nil))
+
+	// Output:
+	// Name: parser
+	// Name: subcommand1
+	// Name: subcommand2
+}
+func ExampleCommand_Help_subcommandHelpFuncs() {
+	parser := NewParser("parser", "")
+	parser.HelpFunc = func(c *Command, msg interface{}) string {
+		helpString := fmt.Sprintf("Name: %s\n", c.GetName())
+		for _, com := range c.GetCommands() {
+			// Calls command.HelpFunc, because command.HelpFuncs are not nil
+			helpString += com.Help(nil)
+		}
+		return helpString
+	}
+	com1 := parser.NewCommand("subcommand1", "Test description")
+	com1.HelpFunc = func(c *Command, msg interface{}) string {
+		helpString := fmt.Sprintf("Name: %s, Description: %s\n", c.GetName(), c.GetDescription())
+		return helpString
+	}
+	com2 := parser.NewCommand("subcommand2", "")
+	com2.String("s", "string", &Options{Required: false})
+	com2.String("i", "integer", &Options{Required: true})
+	com2.HelpFunc = func(c *Command, msg interface{}) string {
+		helpString := fmt.Sprintf("Name: %s\n", c.GetName())
+		for _, arg := range c.GetArgs() {
+			helpString += fmt.Sprintf("\tLname: %s, Required: %t\n", arg.GetLname(), arg.GetOpts().Required)
+		}
+		return helpString
+	}
+	fmt.Print(parser.Help(nil))
+	fmt.Print(com1.Help(nil))
+	fmt.Print(com2.Help(nil))
+
+	// Output:
+	// Name: parser
+	// Name: subcommand1, Description: Test description
+	// Name: subcommand2
+	//	Lname: string, Required: false
+	//	Lname: integer, Required: true
+	// Name: subcommand1, Description: Test description
+	// Name: subcommand2
+	//	Lname: string, Required: false
+	//	Lname: integer, Required: true
+}

--- a/argparse_test.go
+++ b/argparse_test.go
@@ -2,6 +2,7 @@ package argparse
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"reflect"
 	"strconv"
@@ -1178,4 +1179,82 @@ func TestUsageStringer(t *testing.T) {
 	if usage != pUsageStringer {
 		t.Errorf("%s", usage)
 	}
+}
+
+func TestNewParserHelpFuncDefault(t *testing.T) {
+	parser := NewParser("parser", "")
+	if parser.HelpFunc == nil || parser.Help(nil) != parser.Usage(nil) {
+		t.Errorf("HelpFunc should default to Usage function")
+	}
+}
+
+func ExampleCommand_Help() {
+	parser := NewParser("parser", "")
+	parser.HelpFunc = func(c Command, msg interface{}) string {
+		return fmt.Sprintf("Name: %s\n", c.GetName())
+	}
+	fmt.Println(parser.Help(nil))
+
+	// Output:
+	// Name: parser
+}
+
+func ExampleCommand_Help_subcommand_defaulting() {
+	parser := NewParser("parser", "")
+	parser.HelpFunc = func(c Command, msg interface{}) string {
+		helpString := fmt.Sprintf("Name: %s\n", c.GetName())
+		for _, com := range c.GetCommands() {
+			// Calls parser.HelpFunc, because command.HelpFuncs are nil
+			helpString += com.Help(nil)
+		}
+		return helpString
+	}
+	parser.NewCommand("subcommand1", "")
+	parser.NewCommand("subcommand2", "")
+	fmt.Println(parser.Help(nil))
+
+	// Output:
+	// Name: parser
+	// Name: subcommand1
+	// Name: subcommand2
+}
+func ExampleCommand_Help_subcommand_helpfuncs() {
+	parser := NewParser("parser", "")
+	parser.HelpFunc = func(c Command, msg interface{}) string {
+		helpString := fmt.Sprintf("Name: %s\n", c.GetName())
+		for _, com := range c.GetCommands() {
+			// Calls command.HelpFunc, because command.HelpFuncs are not nil
+			helpString += com.Help(nil)
+		}
+		return helpString
+	}
+	com1 := parser.NewCommand("subcommand1", "Test description")
+	com1.HelpFunc = func(c Command, msg interface{}) string {
+		helpString := fmt.Sprintf("Name: %s, Description: %s\n", c.GetName(), c.GetDescription())
+		return helpString
+	}
+	com2 := parser.NewCommand("subcommand2", "")
+	com2.String("s", "string", &Options{Required: false})
+	com2.String("i", "integer", &Options{Required: true})
+	com2.HelpFunc = func(c Command, msg interface{}) string {
+		helpString := fmt.Sprintf("Name: %s\n", c.GetName())
+		for _, arg := range c.GetArgs() {
+			helpString += fmt.Sprintf("\tLname: %s, Required: %t\n", arg.GetLname(), arg.GetOpts().Required)
+		}
+		return helpString
+	}
+	fmt.Print(parser.Help(nil))
+	fmt.Print(com1.Help(nil))
+	fmt.Print(com2.Help(nil))
+
+	// Output:
+	// Name: parser
+	// Name: subcommand1, Description: Test description
+	// Name: subcommand2
+	//	Lname: string, Required: false
+	//	Lname: integer, Required: true
+	// Name: subcommand1, Description: Test description
+	// Name: subcommand2
+	//	Lname: string, Required: false
+	//	Lname: integer, Required: true
 }

--- a/argparse_test.go
+++ b/argparse_test.go
@@ -2,7 +2,6 @@ package argparse
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"reflect"
 	"strconv"
@@ -1186,75 +1185,4 @@ func TestNewParserHelpFuncDefault(t *testing.T) {
 	if parser.HelpFunc == nil || parser.Help(nil) != parser.Usage(nil) {
 		t.Errorf("HelpFunc should default to Usage function")
 	}
-}
-
-func ExampleCommand_Help() {
-	parser := NewParser("parser", "")
-	parser.HelpFunc = func(c Command, msg interface{}) string {
-		return fmt.Sprintf("Name: %s\n", c.GetName())
-	}
-	fmt.Println(parser.Help(nil))
-
-	// Output:
-	// Name: parser
-}
-
-func ExampleCommand_Help_subcommand_defaulting() {
-	parser := NewParser("parser", "")
-	parser.HelpFunc = func(c Command, msg interface{}) string {
-		helpString := fmt.Sprintf("Name: %s\n", c.GetName())
-		for _, com := range c.GetCommands() {
-			// Calls parser.HelpFunc, because command.HelpFuncs are nil
-			helpString += com.Help(nil)
-		}
-		return helpString
-	}
-	parser.NewCommand("subcommand1", "")
-	parser.NewCommand("subcommand2", "")
-	fmt.Println(parser.Help(nil))
-
-	// Output:
-	// Name: parser
-	// Name: subcommand1
-	// Name: subcommand2
-}
-func ExampleCommand_Help_subcommand_helpfuncs() {
-	parser := NewParser("parser", "")
-	parser.HelpFunc = func(c Command, msg interface{}) string {
-		helpString := fmt.Sprintf("Name: %s\n", c.GetName())
-		for _, com := range c.GetCommands() {
-			// Calls command.HelpFunc, because command.HelpFuncs are not nil
-			helpString += com.Help(nil)
-		}
-		return helpString
-	}
-	com1 := parser.NewCommand("subcommand1", "Test description")
-	com1.HelpFunc = func(c Command, msg interface{}) string {
-		helpString := fmt.Sprintf("Name: %s, Description: %s\n", c.GetName(), c.GetDescription())
-		return helpString
-	}
-	com2 := parser.NewCommand("subcommand2", "")
-	com2.String("s", "string", &Options{Required: false})
-	com2.String("i", "integer", &Options{Required: true})
-	com2.HelpFunc = func(c Command, msg interface{}) string {
-		helpString := fmt.Sprintf("Name: %s\n", c.GetName())
-		for _, arg := range c.GetArgs() {
-			helpString += fmt.Sprintf("\tLname: %s, Required: %t\n", arg.GetLname(), arg.GetOpts().Required)
-		}
-		return helpString
-	}
-	fmt.Print(parser.Help(nil))
-	fmt.Print(com1.Help(nil))
-	fmt.Print(com2.Help(nil))
-
-	// Output:
-	// Name: parser
-	// Name: subcommand1, Description: Test description
-	// Name: subcommand2
-	//	Lname: string, Required: false
-	//	Lname: integer, Required: true
-	// Name: subcommand1, Description: Test description
-	// Name: subcommand2
-	//	Lname: string, Required: false
-	//	Lname: integer, Required: true
 }

--- a/argument.go
+++ b/argument.go
@@ -21,12 +21,31 @@ type arg struct {
 	parent   *Command    // Used to get access to specific Command
 }
 
+// Arg interface provides exporting of arg structure, while exposing it
+type Arg interface {
+	GetOpts() *Options
+	GetSname() string
+	GetLname() string
+}
+
+func (o arg) GetOpts() *Options {
+	return o.opts
+}
+
+func (o arg) GetSname() string {
+	return o.sname
+}
+
+func (o arg) GetLname() string {
+	return o.lname
+}
+
 type help struct{}
 
 func (o *arg) check(argument string) bool {
 	// Shortcut to showing help
 	if argument == "-h" || argument == "--help" {
-		helpText := o.parent.Usage(nil)
+		helpText := o.parent.Help(nil)
 		fmt.Print(helpText)
 		os.Exit(0)
 	}
@@ -116,7 +135,7 @@ func (o *arg) parse(args []string) error {
 
 	switch o.result.(type) {
 	case *help:
-		helpText := o.parent.Usage(nil)
+		helpText := o.parent.Help(nil)
 		fmt.Print(helpText)
 		os.Exit(0)
 	case *bool:

--- a/examples/command-help/commands-help.go
+++ b/examples/command-help/commands-help.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+
+	argparse "../.."
+)
+
+func main() {
+	// Create new parser object
+	parser := argparse.NewParser("help", "Demonstrates overriding the default help output")
+	// Replace parser.Usage as the help message
+	parser.HelpFunc = func(c argparse.Command, msg interface{}) string {
+		var help string
+		help += fmt.Sprintf("Name: %s, Description: %s\n", c.GetName(), c.GetDescription())
+		for _, arg := range c.GetArgs() {
+			if arg.GetOpts() != nil {
+				help += fmt.Sprintf("Sname: %s, Lname: %s, Help: %s\n", arg.GetSname(), arg.GetLname(), arg.GetOpts().Help)
+			} else {
+				help += fmt.Sprintf("Sname: %s, Lname: %s\n", arg.GetSname(), arg.GetLname())
+			}
+		}
+		return help
+	}
+
+	// Create command
+	command := parser.NewCommand("sub", "Demonstrates sub command help")
+	// Create string flag
+	command.String("s", "string", &argparse.Options{Required: true, Help: "String argument example"})
+	// Create string flag
+	command.Int("i", "int", &argparse.Options{Required: true, Help: "Integer argument example"})
+	// Without declaring command help function, defaults to first non nil parent help function
+	fmt.Print(command.Help(nil))
+}

--- a/examples/command-help/commands-help.go
+++ b/examples/command-help/commands-help.go
@@ -10,7 +10,7 @@ func main() {
 	// Create new parser object
 	parser := argparse.NewParser("help", "Demonstrates overriding the default help output")
 	// Replace parser.Usage as the help message
-	parser.HelpFunc = func(c argparse.Command, msg interface{}) string {
+	parser.HelpFunc = func(c *argparse.Command, msg interface{}) string {
 		var help string
 		help += fmt.Sprintf("Name: %s, Description: %s\n", c.GetName(), c.GetDescription())
 		for _, arg := range c.GetArgs() {

--- a/examples/command-help/commands-help.go
+++ b/examples/command-help/commands-help.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	argparse "../.."
+	"github.com/akamensky/argparse"
 )
 
 func main() {

--- a/examples/help/help.go
+++ b/examples/help/help.go
@@ -14,7 +14,7 @@ func main() {
 	// Create string flag
 	parser.Int("i", "int", &argparse.Options{Required: true, Help: "Integer argument example"})
 	// Replace parser.Usage as the help message
-	parser.HelpFunc = func(c argparse.Command, msg interface{}) string {
+	parser.HelpFunc = func(c *argparse.Command, msg interface{}) string {
 		var help string
 		help += fmt.Sprintf("Name: %s, Description: %s\n", c.GetName(), c.GetDescription())
 		for _, arg := range c.GetArgs() {

--- a/examples/help/help.go
+++ b/examples/help/help.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+
+	argparse "../.."
+)
+
+func main() {
+	// Create new parser object
+	parser := argparse.NewParser("help", "Demonstrates overriding the default help output")
+	// Create string flag
+	parser.String("s", "string", &argparse.Options{Required: true, Help: "String argument example"})
+	// Create string flag
+	parser.Int("i", "int", &argparse.Options{Required: true, Help: "Integer argument example"})
+	// Replace parser.Usage as the help message
+	parser.HelpFunc = func(c argparse.Command, msg interface{}) string {
+		var help string
+		help += fmt.Sprintf("Name: %s, Description: %s\n", c.GetName(), c.GetDescription())
+		for _, arg := range c.GetArgs() {
+			if arg.GetOpts() != nil {
+				help += fmt.Sprintf("Sname: %s, Lname: %s, Help: %s\n", arg.GetSname(), arg.GetLname(), arg.GetOpts().Help)
+			} else {
+				help += fmt.Sprintf("Sname: %s, Lname: %s\n", arg.GetSname(), arg.GetLname())
+			}
+		}
+		return help
+	}
+	// Use the help function
+	fmt.Print(parser.Help(nil))
+}

--- a/examples/help/help.go
+++ b/examples/help/help.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	argparse "../.."
+	"github.com/akamensky/argparse"
 )
 
 func main() {


### PR DESCRIPTION
Designed to begin addressing issue #29

HelpFunc added as field for Parsers and Commands
Parser HelpFunc defaults to Usage unless overwritten
Command HelpFunc defaults to first non nil parent HelpFunc unless overwritten

Design choice to enable backwards compatibility required
exposing Command and arg fields with Getter functions and an interface.

Does not resolve:
	exiting program on help invocation
	overwrritting/disabling -h | --help argument strings
	enabling other argument strings to invoke help