### PR TITLE
Add positional argument type

### DIFF
--- a/argparse.go
+++ b/argparse.go
@@ -211,7 +211,7 @@ func (o *Command) File(short string, long string, flag int, perm os.FileMode, op
 // List creates new list argument. This is the argument that is allowed to be present multiple times on CLI.
 // All appearances of this argument on CLI will be collected into the list of strings. If no argument
 // provided, then the list is empty. Takes same parameters as String
-// Returns a pointer the list of strings.
+// Returns a pointer to the list of strings.
 func (o *Command) List(short string, long string, opts *Options) *[]string {
 	result := make([]string, 0)
 

--- a/argparse.go
+++ b/argparse.go
@@ -229,6 +229,24 @@ func (o *Command) List(short string, long string, opts *Options) *[]string {
 	return &result
 }
 
+// Positional creates an argument which is a catch-all for any remaining strings left over after parsing.
+// Returns a pointer to the list of strings.
+func (o *Command) Positional(long string, opts *Options) *PositionalResult {
+	var result PositionalResult
+
+	a := &arg{
+		result:     &result,
+		lname:      long,
+		opts:       opts,
+		unique:     true,
+		positional: true,
+	}
+
+	o.addArg(a)
+
+	return &result
+}
+
 // Selector creates a selector argument. Selector argument works in the same way as String argument, with
 // the difference that the string value must be from the list of options provided by the program.
 // Takes short and long names, argument options and a slice of strings which are allowed values
@@ -394,7 +412,11 @@ func (o *Command) Usage(msg interface{}) string {
 			} else {
 				arg = arg + "    "
 			}
-			arg = arg + "--" + argument.lname
+			if argument.positional {
+				arg += argument.lname
+			} else {
+				arg = arg + "--" + argument.lname
+			}
 			arg = arg + strings.Repeat(" ", argPadding-len(arg))
 			if argument.opts != nil && argument.opts.Help != "" {
 				arg = addToLastLine(arg, argument.getHelpMessage(), maxWidth, argPadding, true)

--- a/command.go
+++ b/command.go
@@ -119,6 +119,11 @@ func (o *Command) parse(args *[]string) error {
 		}
 	}
 
+	// assign any unparsed args to positional oarg
+	for _, oarg := range o.args {
+		oarg.assignPositional(args)
+	}
+
 	// Set parsed status to true and return quietly
 	o.parsed = true
 	return nil

--- a/examples/commands-advanced/main.go
+++ b/examples/commands-advanced/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/akamensky/argparse"
-	"github.com/akamensky/argparse/examples/commands-advanced/zoo"
 	"log"
 	"os"
+
+	"github.com/akamensky/argparse"
+	"github.com/akamensky/argparse/examples/commands-advanced/zoo"
 )
 
 func main() {

--- a/examples/commands/commands.go
+++ b/examples/commands/commands.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/akamensky/argparse"
 	"os"
+
+	"github.com/akamensky/argparse"
 )
 
 // Run this as `go run commands.go [start|stop]`

--- a/examples/flags/flags.go
+++ b/examples/flags/flags.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/akamensky/argparse"
 	"os"
+
+	"github.com/akamensky/argparse"
 )
 
 func main() {

--- a/examples/positionals/positionals.go
+++ b/examples/positionals/positionals.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/akamensky/argparse"
+)
+
+func main() {
+	// Create new parser object
+	parser := argparse.NewParser("positionals", "Prints provided positional strings to stdout")
+	// Create string flag
+	s := parser.String("s", "string", &argparse.Options{Required: true, Help: "String to print"})
+	p := parser.Positional("positional", &argparse.Options{Help: "More strings to print"})
+	// Parse input
+	err := parser.Parse(os.Args)
+	if err != nil {
+		// In case of error print error and print usage
+		// This can also be done by passing -h or --help flags
+		fmt.Print(parser.Usage(err))
+		os.Exit(1)
+	}
+	// Finally print the collected string
+	fmt.Println(*s)
+	fmt.Println(*p)
+}

--- a/examples/print/print.go
+++ b/examples/print/print.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/akamensky/argparse"
 	"os"
+
+	"github.com/akamensky/argparse"
 )
 
 func main() {

--- a/examples/required-args/required-args.go
+++ b/examples/required-args/required-args.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/akamensky/argparse"
 	"os"
+
+	"github.com/akamensky/argparse"
 )
 
 func main() {

--- a/examples/sleep/sleep.go
+++ b/examples/sleep/sleep.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/akamensky/argparse"
 	"os"
 	"time"
+
+	"github.com/akamensky/argparse"
 )
 
 func main() {


### PR DESCRIPTION
Add the ability to accept positional arguments by adding a parser.Positional() argument type that simply collects all of the remaining unparsed arguments and returns them as a list of strings.  Example code in examples/positionals/positionals.go.  Still needs tests.

The Nargs additions that @jokelyo made in http://github.com/jokelyo/argparse also look promising; I considered extending that to get positionals.  The upside there would be the ability to handle more positional types than just strings; the downside would be a much larger code delta. 