### PR TITLE
Fix Issue 59

### DIFF
--- a/argparse.go
+++ b/argparse.go
@@ -441,10 +441,11 @@ func (o *Command) Selector(short string, long string, options []string, opts *Op
 	return &result
 }
 
-// message2String - puts msg in result string
+// message2String puts msg in result string
+// done boolean indicates if result is ready to be returned
 // Accepts an interface that can be error, string or fmt.Stringer that will be prepended to a message.
 // All other interface types will be ignored
-func message2String(msg interface{}) string {
+func message2String(msg interface{}) (string, bool) {
 	var result string
 	if msg != nil {
 		switch msg.(type) {
@@ -453,7 +454,7 @@ func message2String(msg interface{}) string {
 			if msg.(subCommandError).cmd != nil {
 				result += msg.(subCommandError).cmd.Usage(nil)
 			}
-			return result
+			return result, true
 		case error:
 			result = fmt.Sprintf("%s\n", msg.(error).Error())
 		case string:
@@ -462,7 +463,7 @@ func message2String(msg interface{}) string {
 			result = fmt.Sprintf("%s\n", msg.(fmt.Stringer).String())
 		}
 	}
-	return result
+	return result, false
 }
 
 // getPrecedingCommands - collects info on command chain from root to current (o *Command) and all arguments in this chain
@@ -611,7 +612,6 @@ func (o *Command) Usage(msg interface{}) string {
 		}
 	}
 
-	var result string
 	// Stay classy
 	maxWidth := 80
 	// List of arguments from all preceding commands
@@ -619,8 +619,11 @@ func (o *Command) Usage(msg interface{}) string {
 	// Line of commands until root
 	var chain []string
 
-	// Put message in resultz
-	result = message2String(msg)
+	// Put message in result
+	result, done := message2String(msg)
+	if done {
+		return result
+	}
 
 	//collect info about Preceding Commands into chain and arguments
 	o.getPrecedingCommands(&chain, &arguments)

--- a/argparse_test.go
+++ b/argparse_test.go
@@ -1702,6 +1702,36 @@ func TestUsageHidden1(t *testing.T) {
 	}
 }
 
+func TestUsageSubCommand(t *testing.T) {
+	expected := `[sub]Command required
+usage: zooprog <Command> [-h|--help]
+
+               Program that walks us through the zoo
+
+Commands:
+
+  dog  We are going to see dog
+
+Arguments:
+
+  -h  --help  Print help information
+
+`
+
+	parser := NewParser("zooprog", "Program that walks us through the zoo")
+
+	// dog command
+	parser.
+		NewCommand("dog", "We are going to see dog"). // adds command to parser
+		NewCommand("speak", "Make the dog speak")     // adds subcommand to previous command
+
+	err := newSubCommandError(&parser.Command)
+	actual := parser.Usage(err)
+	if expected != actual {
+		t.Errorf("Expectations unmet. expected: %s, actual: %s", expected, actual)
+	}
+}
+
 func TestStringMissingArgFail(t *testing.T) {
 	testArgs := []string{"progname", "-s"}
 


### PR DESCRIPTION
Fix for [Repeated Text in subcommand usage text](https://github.com/akamensky/argparse/issues/59). The bug was introduced in https://github.com/akamensky/argparse/commit/112b813b83328a106c169377866b5c7c9d308eca where Usage method functionality was extracted into separate functions. Previously when a subcommand error was found, Usage was called recursively and the result string was returned. After being extracted to a unction that case was not being handled. I simply added a boolean flag to indicate that. Added a basic test to verify usage would not repeat.