### PR TITLE
Arg can return the result pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ You can implement sub-commands in your CLI using `parser.NewCommand()` or go eve
 Since parser inherits from command, every command supports exactly same options as parser itself,
 thus allowing to add arguments specific to that command or more global arguments added on parser itself!
 
+You can also dynamically retrieve argument values:
+```
+var myInteger *int = parser.Int("i", "integer", ...)
+parser.Parse()
+fmt.Printf("%d", *parser.GetArgs()[0].GetResult().(*int))
+```
+
 #### Basic Option Structure
 
 The `Option` structure is declared at `argparse.go`:

--- a/argparse_test.go
+++ b/argparse_test.go
@@ -147,6 +147,33 @@ func TestFlagSimple1(t *testing.T) {
 		t.Errorf("Test %s failed with flag2 being true", t.Name())
 		return
 	}
+
+	if args := p.GetArgs(); args == nil {
+		t.Errorf("Test %s failed with args empty", t.Name())
+	} else if len(args) != 3 { // our two and -h
+		t.Errorf("Test %s failed with wrong len", t.Name())
+	} else {
+		got := 0
+		for _, arg := range args {
+			switch arg.GetLname() {
+			case "flag-arg1":
+				if *arg.GetResult().(*bool) != *flag1 {
+					t.Errorf("Test %s failed with wrong arg value", t.Name())
+				}
+				got += 3
+			case "flag-arg2":
+				if *arg.GetResult().(*bool) != *flag2 {
+					t.Errorf("Test %s failed with wrong arg value", t.Name())
+				}
+				got += 5
+			case "help":
+				got += 11
+			}
+		}
+		if got != 19 {
+			t.Errorf("Test %s failed with wrong args found", t.Name())
+		}
+	}
 }
 
 func TestFlagSimple2(t *testing.T) {
@@ -192,6 +219,7 @@ func TestFlagSimple2(t *testing.T) {
 		t.Errorf("Test %s failed with flag3 being false", t.Name())
 		return
 	}
+
 }
 
 func TestLongFlagEqualChar(t *testing.T) {
@@ -696,6 +724,33 @@ func TestStringSimple1(t *testing.T) {
 	if *s2 != "" {
 		t.Errorf("Test %s failed. Want: [%s], got: [%s]", t.Name(), "\"\"", *s1)
 		return
+	}
+
+	if args := p.GetArgs(); args == nil {
+		t.Errorf("Test %s failed with args empty", t.Name())
+	} else if len(args) != 3 { // our two + help
+		t.Errorf("Test %s failed with wrong len", t.Name())
+	} else {
+		got := 0
+		for _, arg := range args {
+			switch arg.GetLname() {
+			case "flag-arg1":
+				if *arg.GetResult().(*string) != *s1 {
+					t.Errorf("Test %s failed with wrong arg value", t.Name())
+				}
+				got += 3
+			case "flag-arg2":
+				if *arg.GetResult().(*string) != "" {
+					t.Errorf("Test %s failed with non-nil result", t.Name())
+				}
+				got += 5
+			case "help":
+				got += 11
+			}
+		}
+		if got != 19 {
+			t.Errorf("Test %s failed with wrong args found", t.Name())
+		}
 	}
 }
 

--- a/argument.go
+++ b/argument.go
@@ -43,6 +43,8 @@ func (o arg) GetLname() string {
 	return o.lname
 }
 
+// getResult returns the interface{} to the *(type) containing the argument's result value
+// Will contain the empty/default value if argument value was not given
 func (o arg) GetResult() interface{} {
 	return o.result
 }

--- a/argument.go
+++ b/argument.go
@@ -28,6 +28,7 @@ type Arg interface {
 	GetOpts() *Options
 	GetSname() string
 	GetLname() string
+	GetResult() interface{}
 }
 
 func (o arg) GetOpts() *Options {
@@ -40,6 +41,10 @@ func (o arg) GetSname() string {
 
 func (o arg) GetLname() string {
 	return o.lname
+}
+
+func (o arg) GetResult() interface{} {
+	return o.result
 }
 
 type help struct{}

--- a/examples/commands/commands.go
+++ b/examples/commands/commands.go
@@ -16,6 +16,7 @@ func main() {
 
 	// Add top level commands `stop`
 	stopCmd := parser.NewCommand("stop", "Will stop a process")
+	stopCmd.Int("-t", "--time", nil)
 
 	// Parse command line arguments and in case of any error print error and help information
 	err := parser.Parse(os.Args)
@@ -30,6 +31,12 @@ func main() {
 		fmt.Println("Started process")
 	} else if stopCmd.Happened() { // Check if `stop` command was given
 		// Stopping a process
+		for _, arg := range stopCmd.GetArgs() {
+			switch val := arg.GetResult().(type) {
+			case int:
+				fmt.Printf("Arg: %s = %d\n", arg.GetLname(), val)
+			}
+		}
 		fmt.Println("Stopped process")
 	} else {
 		// In fact we will never hit this one


### PR DESCRIPTION
This allows for more dynamic flag/arg handling, such as scenarios where:
 * multiple commands each have their own unique flags that you don't want to track individually
 * multiple commands share some subset of flags that don't fit on the main parser

```
~/git/github.com/vsachs/argparse| go test
PASS
ok      github.com/akamensky/argparse   0.015s
```