### PR TITLE
Multiline descriptions and help messages

### DIFF
--- a/argparse.go
+++ b/argparse.go
@@ -18,15 +18,16 @@ var disableHelp = false
 // Command MUST NOT ever be created manually. Instead one should call NewCommand method of Parser or Command,
 // which will setup appropriate fields and call methods that have to be called when creating new command.
 type Command struct {
-	name        string
-	description string
-	args        []*arg
-	commands    []*Command
-	parsed      bool
-	happened    bool
-	parent      *Command
-	HelpFunc    func(c *Command, msg interface{}) string
-	exitOnHelp  bool
+	name               string
+	description        string
+	args               []*arg
+	commands           []*Command
+	parsed             bool
+	happened           bool
+	parent             *Command
+	HelpFunc           func(c *Command, msg interface{}) string
+	exitOnHelp         bool
+	DescriptionPadding interface{}
 }
 
 // GetName exposes Command's name field
@@ -116,6 +117,7 @@ func NewParser(name string, description string) *Parser {
 	p.help("h", "help")
 	p.exitOnHelp = true
 	p.HelpFunc = (*Command).Usage
+	p.DescriptionPadding = nil
 
 	return p
 }
@@ -538,6 +540,12 @@ func (o *Command) precedingCommands2Result(result string, chain []string, argume
 		if v.lname == "help" || v.sname == "h" {
 			usedHelp = true
 		}
+	}
+	// Set custom padding
+	customPadding, ok := o.DescriptionPadding.(int)
+	if ok {
+		// -1 because addTolastline inserts extra space
+		leftPadding = customPadding - 1
 	}
 	// Add program/Command description to the result
 	result = result + "\n\n" + strings.Repeat(" ", leftPadding)

--- a/argparse_test.go
+++ b/argparse_test.go
@@ -2708,7 +2708,32 @@ Arguments:
 
 	parser := NewParser("command", "Program with multiline\ndescription.")
 
-		parser.String("s", "string", &Options{Required: true, Help: "String argument example\non several lines"})
+	parser.String("s", "string", &Options{Required: true, Help: "String argument example\non several lines"})
+
+	actual := parser.Help(nil)
+	if expected != actual {
+		t.Errorf("Expectations unmet. expected: %s, actual: %s", expected, actual)
+	}
+}
+
+func TestCommandHelpMultilineWithCustomPadding(t *testing.T) {
+	expected := `usage: command [-h|--help] -s|--string "<value>"
+
+   Program with multiline
+   description.
+
+Arguments:
+
+  -h  --help    Print help information
+  -s  --string  String argument example
+                on several lines
+
+`
+
+	parser := NewParser("command", "Program with multiline\ndescription.")
+
+	parser.String("s", "string", &Options{Required: true, Help: "String argument example\non several lines"})
+	parser.DescriptionPadding = 3
 
 	actual := parser.Help(nil)
 	if expected != actual {

--- a/argparse_test.go
+++ b/argparse_test.go
@@ -2691,3 +2691,27 @@ func TestCommandHelpSetSnameOnly(t *testing.T) {
 		t.Error("Help arugment names should have defaulted")
 	}
 }
+
+func TestCommandHelpMultiline(t *testing.T) {
+	expected := `usage: command [-h|--help] -s|--string "<value>"
+
+               Program with multiline
+               description.
+
+Arguments:
+
+  -h  --help    Print help information
+  -s  --string  String argument example
+                on several lines
+
+`
+
+	parser := NewParser("command", "Program with multiline\ndescription.")
+
+		parser.String("s", "string", &Options{Required: true, Help: "String argument example\non several lines"})
+
+	actual := parser.Help(nil)
+	if expected != actual {
+		t.Errorf("Expectations unmet. expected: %s, actual: %s", expected, actual)
+	}
+}

--- a/examples/custompadding/custompadding.go
+++ b/examples/custompadding/custompadding.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/akamensky/argparse"
+)
+
+func main() {
+	// Create new parser object
+	parser := argparse.NewParser("help",
+		`Demonstrates multiline description and help messages.
+With some very long lines like this one which is broken automatically by argparse.
+And some shorter.`)
+	// Create string flag
+	parser.String("s", "string", &argparse.Options{Required: true, Help: "String argument example\non several lines"})
+	// Create string flag
+	parser.Int("i", "int", &argparse.Options{Required: true, Help: "Integer argument example"})
+	parser.DescriptionPadding = 3
+	// Use the help function
+	fmt.Print(parser.Help(nil))
+}

--- a/examples/multiline/multiline.go
+++ b/examples/multiline/multiline.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/akamensky/argparse"
+)
+
+func main() {
+	// Create new parser object
+	parser := argparse.NewParser("help",
+		`Demonstrates multiline description and help messages.
+With some very long lines like this one which is broken automatically by argparse.
+And some shorter.`)
+	// Create string flag
+	parser.String("s", "string", &argparse.Options{Required: true, Help: "String argument example\non several lines"})
+	// Create string flag
+	parser.Int("i", "int", &argparse.Options{Required: true, Help: "Integer argument example"})
+	// Use the help function
+	fmt.Print(parser.Help(nil))
+}

--- a/extras.go
+++ b/extras.go
@@ -8,6 +8,21 @@ func getLastLine(input string) string {
 }
 
 func addToLastLine(base string, add string, width int, padding int, canSplit bool) string {
+	// Split the multiline string to add
+	if strings.Contains(add, "\n") {
+		lines := strings.Split(add, "\n")
+		firstLine := true
+		for _, v := range lines {
+			if firstLine {
+				base = addToLastLine(base, v, width, padding, true)
+				firstLine = false
+			} else {
+				base = base + "\n" + strings.Repeat(" ", padding)
+				base = addToLastLine(base, v, width, padding, true)
+			}
+		}
+		return base
+	}
 	// If last line has less than 10% space left, do not try to fill in by splitting else just try to split
 	hasTen := (width - len(getLastLine(base))) > width/10
 	if len(getLastLine(base)+" "+add) >= width {


### PR DESCRIPTION
This allows to break the description and help messages without messing up the formatting.
Closes #70 