### PR TITLE
Ensure argument options is not nil

### DIFF
--- a/argparse.go
+++ b/argparse.go
@@ -117,6 +117,9 @@ type Options struct {
 	positional bool
 }
 
+// Default argument options to use when user does not specify them.
+var DefaultArgOptions = Options{}
+
 // NewParser creates new Parser object that will allow to add arguments for parsing
 // It takes program name and description which will be used as part of Usage output
 // Returns pointer to Parser object

--- a/command.go
+++ b/command.go
@@ -52,6 +52,11 @@ func (o *Command) addArg(a *arg) error {
 	}
 	a.parent = o
 
+	// Ensure Options pointer is not nil; use default options if none provided
+	if a.opts == nil {
+		a.opts = &Options{}
+	}
+
 	if a.GetPositional() {
 		switch a.argType { // Secondary guard
 		case Flag, FlagCounter, StringList, IntList, FloatList, FileList:

--- a/command.go
+++ b/command.go
@@ -54,7 +54,8 @@ func (o *Command) addArg(a *arg) error {
 
 	// Ensure Options pointer is not nil; use default options if none provided
 	if a.opts == nil {
-		a.opts = &Options{}
+		opts := DefaultArgOptions
+		a.opts = &opts
 	}
 
 	if a.GetPositional() {


### PR DESCRIPTION
This prevents SIGSEGVs when accessing the argument's options.

This issue was discovered due to a SIGSEGV when trying to print the help message of argument with no options.

Minimal reproduction program:

```go
package main

import (
	"os"

	"github.com/akamensky/argparse"
)

func main() {
	p := argparse.NewParser("noopts", "")
	_ = p.String("s", "string", nil)
	_ = p.Parse(os.Args)
}
```

```sh
$ go run noopts.go -h
panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x49e5a3]

goroutine 1 [running]:
github.com/akamensky/argparse.(*Command).precedingCommands2Result(0xc000114000, {0x4ca231, 0x6}, {0xc00001e200, 0x1, 0x4c0c60?}, {0xc00001e210, 0x2, 0x474647?}, 0x50)
        /some_path/argparse/argparse.go:619 +0x163
github.com/akamensky/argparse.(*Command).Usage(0xc000114000, {0x0?, 0x0?})
        /some_path/argparse/argparse.go:753 +0x4bf
github.com/akamensky/argparse.(*Command).Help(0x49c6c5?, {0x0?, 0x0?})
        /some_path/argparse/argparse.go:75 +0x47
github.com/akamensky/argparse.(*arg).parseSomeType(0xc00002a080, {0xc0000120b0?, 0x5a31c0?, 0x400000?}, 0xc000104c18?)
        /some_path/argparse/argument.go:395 +0x85
github.com/akamensky/argparse.(*arg).parse(0x7ffc543f5cf3?, {0xc0000120b0?, 0x4c9f7f?, 0x10?}, 0x5839c0?)
        /some_path/argparse/argument.go:445 +0x371
github.com/akamensky/argparse.(*Command).parseArguments(0x1?, 0xc000104ed0)
        /some_path/argparse/command.go:170 +0x405
github.com/akamensky/argparse.(*Command).parse(0xc000114000, 0xc000104ed0)
        /some_path/argparse/command.go:231 +0x10b
github.com/akamensky/argparse.(*Parser).Parse(0xc000114000, {0xc000012080?, 0x2, 0x4ca22b?})
        /some_path/argparse/argparse.go:772 +0x76
main.main()
        /some_path/argparse/examples/noopts.go:12 +0x6b
exit status 2
```